### PR TITLE
Extend Happy process management to root-namespaced proceesses

### DIFF
--- a/happy/HappyProcess.py
+++ b/happy/HappyProcess.py
@@ -176,6 +176,9 @@ class HappyProcess(HappyHost):
 
         procs = self.GetProcessTreeAsList(pid, create_time)
 
+        self.TerminateProcesses(procs)
+
+    def TerminateProcesses(self, procs):
         # first send SIGUSR1
         self.__signal_procs(procs, "SIGUSR1")
 
@@ -190,3 +193,15 @@ class HappyProcess(HappyHost):
         if alive:
             # if process is still around, just kill it
             self.__signal_procs(alive, "SIGKILL")
+
+    def GetProcessByName(self, name):
+        # TODO: Sometimes pid is there, but psutil cannot get this process, need to fix it.
+        processlist = []
+        for pid in psutil.get_pid_list():
+            try:
+                p = psutil.Process(pid)
+                if p.name == name:
+                    processlist.append(p)
+            except:
+                pass
+        return processlist

--- a/happy/HappyProcessOutput.py
+++ b/happy/HappyProcessOutput.py
@@ -50,7 +50,7 @@ class HappyProcessOutput(HappyNode):
     happy-process-output [-h --help] [-q --quiet] [-i --id <NODE_NAME>]
                          [-t --tag <DAEMON_NAME>]
 
-        -i --id     Required. Node on which the process is running. Find
+        -i --id     Optional. Node on which the process is running. Find
                     using happy-node-list or happy-state.
         -t --tag    Required. Name of the process.
 
@@ -73,18 +73,6 @@ class HappyProcessOutput(HappyNode):
         self.process_output = None
 
     def __pre_check(self):
-        # Check if the name of the node is given
-        if not self.node_id:
-            emsg = "Missing name of the virtual node."
-            self.logger.error("[localhost] HappyProcessOutput: %s" % (emsg))
-            self.RaiseError(emsg)
-
-        # Check if the name of new node is not a duplicate (that it does not already exists).
-        if not self._nodeExists():
-            emsg = "virtual node %s does not exist." % (self.node_id)
-            self.logger.error("[%s] HappyProcessOutput: %s" % (self.node_id, emsg))
-            self.RaiseError(emsg)
-
         # Check if the new process is given
         if not self.tag:
             emsg = "Missing name of the process to retrieve output from."

--- a/happy/HappyProcessStop.py
+++ b/happy/HappyProcessStop.py
@@ -52,7 +52,7 @@ class HappyProcessStop(HappyNode, HappyProcess):
     happy-process-stop [-h --help] [-q --quiet] [-i --id <NODE_NAME>]
                        [-t --tag <DAEMON_NAME>]
 
-        -i --id     Required. Node on which the process is running. Find
+        -i --id     Optional. Node on which the process is running. Find
                     using happy-node-list or happy-state.
         -t --tag    Required. Name of the process.
 
@@ -78,18 +78,6 @@ class HappyProcessStop(HappyNode, HappyProcess):
         self.process_exists = True
 
     def __pre_check(self):
-        # Check if the name of the node is given
-        if not self.node_id:
-            emsg = "Missing name of the virtual node that should stop process."
-            self.logger.error("[localhost] HappyProcessStop: %s" % (emsg))
-            self.RaiseError()
-
-        # Check if the node exists
-        if not self._nodeExists():
-            emsg = "virtual node %s does not exist." % (self.node_id)
-            self.logger.error("[%s] HappyProcessStop: %s" % (self.node_id, emsg))
-            self.RaiseError()
-
         # Check if the tag is given
         if not self.tag:
             emsg = "Missing name of the process to be stopped."

--- a/happy/HappyProcessStrace.py
+++ b/happy/HappyProcessStrace.py
@@ -50,7 +50,7 @@ class HappyProcessStrace(HappyNode):
     happy-process-strace [-h --help] [-q --quiet] [-i --id <NODE_NAME>]
                          [-t --tag <DAEMON_NAME>]
 
-        -i --id     Required. Node on which the process is running. Find using
+        -i --id     Optional. Node on which the process is running. Find using
                     happy-node-list or happy-state.
         -t --tag    Required. Name of the process.
 
@@ -73,18 +73,6 @@ class HappyProcessStrace(HappyNode):
         self.process_strace = None
 
     def __pre_check(self):
-        # Check if the name of the node is given
-        if not self.node_id:
-            emsg = "Missing name of the virtual node."
-            self.logger.error("[localhost] HappyProcessStrace: %s" % (emsg))
-            self.RaiseError()
-
-        # Check if the name of new node is not a duplicate (that it does not already exists).
-        if not self._nodeExists():
-            emsg = "virtual node %s does not exist." % (self.node_id)
-            self.logger.error("[%s] HappyProcessStrace: %s" % (self.node_id, emsg))
-            self.RaiseError()
-
         # Check if the new process is given
         if not self.tag:
             emsg = "Missing name of the process to retrieve strace from."

--- a/happy/HappyProcessWait.py
+++ b/happy/HappyProcessWait.py
@@ -52,7 +52,7 @@ class HappyProcessWait(HappyNode, HappyProcess):
     happy-process-wait [-h --help] [-q --quiet] [-i --id <NODE_NAME>]
                        [-t --tag <DAEMON_NAME>]
 
-        -i --id     Required. Node on which the process is running. Find
+        -i --id     Optional. Node on which the process is running. Find
                     using happy-node-list or happy-state.
         -t --tag    Required. Name of the process.
 
@@ -77,18 +77,6 @@ class HappyProcessWait(HappyNode, HappyProcess):
         self.done = False
 
     def __pre_check(self):
-        # Check if the name of the node is given
-        if not self.node_id:
-            emsg = "Missing name of the virtual node that should stop process."
-            self.logger.error("[localhost] HappyProcessWait: %s" % (emsg))
-            self.RaiseError()
-
-        # Check if the name of new node is not a duplicate (that it does not already exists).
-        if not self._nodeExists():
-            emsg = "virtual node %s does not exist." % (self.node_id)
-            self.logger.error("[%s] HappyProcessWait: %s" % (self.node_id, emsg))
-            self.RaiseError()
-
         # Check if the new process is given
         if not self.tag:
             emsg = "Missing name of the process to be stopped."


### PR DESCRIPTION
1. For HappyProcessStart, add functionality to make process run with
sudo root mode in container.
2. Add TerminateProcesses and GetProcessByName in HappyProcess
3. In the past, Happy does not support to run command on root namespace
and only support to run command in node. We need to support to run
command in root namespace to run btvirt and bluetoothd.