### PR TITLE
change IP.py to module util

### DIFF
--- a/happy/Driver.py
+++ b/happy/Driver.py
@@ -36,7 +36,7 @@ import sys
 import time
 import happy.HappyLogger as HappyLogger
 
-from happy.IP import IP
+from happy.utils.IP import IP
 from happy.Utils import *
 
 log_config = "conf/log_config.json"
@@ -120,10 +120,8 @@ class StateLockManager(object):
         self.state_lock.break_lock()
 
 
-class Driver(IP):
+class Driver:
     def __init__(self):
-        IP.__init__(self)
-
         self.state = {}
         self.isp_state = {}
         self.configuration = {}

--- a/happy/HappyDNS.py
+++ b/happy/HappyDNS.py
@@ -28,6 +28,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 
 options = {}
@@ -87,7 +88,7 @@ class HappyDNS(HappyNode):
             self.exit()
 
         for dns_addr in self.dns:
-            if not self.isIpv4(dns_addr):
+            if not IP.isIpv4(dns_addr):
                 emsg = "DNS %s is not a valid IPv4 address." % (dns_addr)
                 self.logger.error("[localhost] HappyDNS: %s" % (emsg))
                 self.exit()

--- a/happy/HappyNetwork.py
+++ b/happy/HappyNetwork.py
@@ -28,6 +28,7 @@ import os
 import sys
 
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyHost import HappyHost
 import happy.HappyLinkDelete
 
@@ -147,7 +148,7 @@ class HappyNetwork(HappyHost):
             return 100
 
         for ip in all_ips:
-            if self.isIpv6(ip):
+            if IP.isIpv6(ip):
                 continue
 
             ip_list = ip.split(".")

--- a/happy/HappyNetworkAdd.py
+++ b/happy/HappyNetworkAdd.py
@@ -30,6 +30,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNetwork import HappyNetwork
 import happy.HappyNetworkAddress
 import happy.HappyNetworkDelete
@@ -89,7 +90,7 @@ class HappyNetworkAdd(HappyNetwork):
             self.exit()
 
         # Check if dot is in the name
-        if self.isDomainName(self.network_id):
+        if IP.isDomainName(self.network_id):
             emsg = "Using . (dot) in the name is not allowed."
             self.logger.error("[localhost] HappyNetworkAdd: %s" % (emsg))
             self.exit()

--- a/happy/HappyNetworkAddress.py
+++ b/happy/HappyNetworkAddress.py
@@ -30,6 +30,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNetwork import HappyNetwork
 from happy.HappyNode import HappyNode
 import happy.HappyNodeAddress
@@ -99,8 +100,8 @@ class HappyNetworkAddress(HappyNetwork, HappyNode):
             self.logger.error("[%s] HappyNetworkAddress: %s" % (self.network_id, emsg))
             self.exit()
 
-        self.ip_prefix, self.ip_mask = self.splitAddressMask(self.address)
-        self.ip_prefix = self.getPrefix(self.ip_prefix, self.ip_mask)
+        self.ip_prefix, self.ip_mask = IP.splitAddressMask(self.address)
+        self.ip_prefix = IP.getPrefix(self.ip_prefix, self.ip_mask)
 
         # Check if successfully parsed prefix
         if self.ip_prefix is None or self.ip_mask is None:
@@ -129,7 +130,7 @@ class HappyNetworkAddress(HappyNetwork, HappyNode):
             interface_id = self.getNodeInterfaceFromLink(link_id, node_id)
             options["interface"] = interface_id
 
-            if self.isIpv6(self.address):
+            if IP.isIpv6(self.address):
                 nid = self.getInterfaceId(interface_id, node_id)
             else:
                 nid = self.getNextNetworkIPv4Id(self.ip_prefix, self.network_id)

--- a/happy/HappyNetworkRoute.py
+++ b/happy/HappyNetworkRoute.py
@@ -30,6 +30,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNetwork import HappyNetwork
 from happy.HappyNode import HappyNode
 import happy.HappyNodeRoute
@@ -137,13 +138,13 @@ class HappyNetworkRoute(HappyNetwork, HappyNode):
             self.exit()
 
         # Check for mix IP addresses
-        if self.isIpAddress(self.to) and self.isIpAddress(self.via) and self.isIpv6(self.to) != self.isIpv6(self.via):
+        if IP.isIpAddress(self.to) and IP.isIpAddress(self.via) and IP.isIpv6(self.to) != IP.isIpv6(self.via):
             emsg = "Mixing addresses %s and %s." % (self.to, self.via)
             self.logger.error("[%s] HappyNetworkRoute: %s" % (self.node_id, emsg))
             self.exit()
 
         # Check if destination is a node
-        if self.to != "default" and not self.isIpAddress(self.to):
+        if self.to != "default" and not IP.isIpAddress(self.to):
             if not self._nodeExists(self.to):
                 emsg = "Don't know what %s to-address is. If it is a node, it can't be found." % (self.to)
                 self.logger.error("[localhost] HappyNetworkRoute: %s" % (emsg))
@@ -154,12 +155,12 @@ class HappyNetworkRoute(HappyNetwork, HappyNode):
                 self.logger.error("[localhost] HappyNetworkRoute: %s" % (emsg))
                 self.exit()
 
-        if self.isIpAddress(self.to):
-            self.to = self.paddingZeros(self.to)
+        if IP.isIpAddress(self.to):
+            self.to = IP.paddingZeros(self.to)
 
         # Check if gateway is an address or a node
-        if self.isIpAddress(self.via):
-            self.via = self.paddingZeros(self.via)
+        if IP.isIpAddress(self.via):
+            self.via = IP.paddingZeros(self.via)
             self.via_node = self.getNodeIdFromAddress(self.via)
 
             if self.via_node is None or not self._nodeExists(self.via_node):

--- a/happy/HappyNode.py
+++ b/happy/HappyNode.py
@@ -28,6 +28,7 @@ import os
 import sys
 
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyHost import HappyHost
 import happy.HappyLinkDelete
 
@@ -132,7 +133,7 @@ class HappyNode(HappyHost):
             if l[0][:4] == "inet":
                 addr = l[1]
                 addr, mask = addr.split("/")
-                addr = self.paddingZeros(addr)
+                addr = IP.paddingZeros(addr)
                 ipaddrs.append(addr)
 
         return ipaddrs
@@ -145,7 +146,7 @@ class HappyNode(HappyHost):
             if l[0][:4] == "inet":
                 addr = l[1]
                 addr, mask = addr.split("/")
-                addr = self.paddingZeros(addr)
+                addr = IP.paddingZeros(addr)
                 if addr != address:
                     continue
 
@@ -183,7 +184,7 @@ class HappyNode(HappyHost):
             hwAddr = self.getHwAddress(interface_id, node_id)
 
             if hwAddr is not None:
-                eui = self.MAC48toEUI64(hwAddr)
+                eui = IP.MAC48toEUI64(hwAddr)
 
         return eui
 
@@ -193,29 +194,29 @@ class HappyNode(HappyHost):
         if eui is None:
             return None
 
-        iid = self.EUI64toIID(eui)
+        iid = IP.EUI64toIID(eui)
         return iid
 
     def getNodeAddressOnPrefix(self, prefix, id):
-        if self.isIpv6(prefix):
+        if IP.isIpv6(prefix):
             return self.__getNodeIPv6AddressOnPrefix(prefix, id)
         else:
             return self.__getNodeIPv4AddressOnPrefix(prefix, id)
 
     def __getNodeIPv6AddressOnPrefix(self, prefix, id):
-        prefix_addr, prefix_mask = self.splitAddressMask(prefix)
+        prefix_addr, prefix_mask = IP.splitAddressMask(prefix)
 
         addr = prefix_addr + "::" + id
 
         if addr.count(":") == 8:
             addr = addr.replace("::", ":")
 
-        addr = self.paddingZeros(addr)
+        addr = IP.paddingZeros(addr)
 
         return addr
 
     def __getNodeIPv4AddressOnPrefix(self, prefix, id):
-        prefix_addr, prefix_mask = self.splitAddressMask(prefix)
+        prefix_addr, prefix_mask = IP.splitAddressMask(prefix)
         prefix_mask = int(float(prefix_mask))
 
         addr = prefix_addr.split(".")[:prefix_mask / 8]

--- a/happy/HappyNodeAdd.py
+++ b/happy/HappyNodeAdd.py
@@ -30,6 +30,7 @@ import time
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 import happy.HappyNodeDelete
 import happy.HappyDNS
@@ -95,7 +96,7 @@ class HappyNodeAdd(HappyNode):
             self.exit()
 
         # Check if dot is in the name
-        if self.isDomainName(self.node_id):
+        if IP.isDomainName(self.node_id):
             emsg = "Using . (dot) in the name is not allowed."
             self.logger.error("[localhost] HappyNodeAdd: %s" % (emsg))
             self.exit()

--- a/happy/HappyNodeAddress.py
+++ b/happy/HappyNodeAddress.py
@@ -29,6 +29,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 
 options = {}
@@ -110,14 +111,14 @@ class HappyNodeAddress(HappyNode):
             self.logger.error("[%s] HappyNodeAddress: %s" % (self.node_id, emsg))
             self.exit()
 
-        self.ip_address, self.ip_mask = self.splitAddressMask(self.address)
-        self.ip_address = self.paddingZeros(self.ip_address)
+        self.ip_address, self.ip_mask = IP.splitAddressMask(self.address)
+        self.ip_address = IP.paddingZeros(self.ip_address)
 
         if not self.delete:
             self.add = True
 
         # Check if node has given prefix
-        addr_prefix = self.getPrefix(self.ip_address, self.ip_mask)
+        addr_prefix = IP.getPrefix(self.ip_address, self.ip_mask)
         if self.delete and addr_prefix not in self.getNodeInterfacePrefixes(self.interface):
             emsg = "virtual node %s may not have any addresses on prefix %s." % (self.node_id, addr_prefix)
             self.logger.warning("[%s] HappyNodeAddress: %s" % (self.node_id, emsg))
@@ -131,7 +132,7 @@ class HappyNodeAddress(HappyNode):
     def __add_address(self):
         cmd = "ip "
 
-        if self.isIpv6(self.address):
+        if IP.isIpv6(self.address):
             cmd += "-6 "
 
         cmd += "addr add " + str(self.ip_address) + "/" + str(self.ip_mask) + " dev " + self.interface
@@ -147,7 +148,7 @@ class HappyNodeAddress(HappyNode):
 
     def __delete_address(self):
         cmd = "ip "
-        if self.isIpv6(self.address):
+        if IP.isIpv6(self.address):
             cmd += "-6 "
         cmd += "addr del " + str(self.ip_address) + "/" + str(self.ip_mask) + " dev " + self.interface
 
@@ -160,7 +161,7 @@ class HappyNodeAddress(HappyNode):
         has_ip = False
 
         for iaddr in ipaddrs:
-            addr_part, _ = self.splitAddressMask(iaddr)
+            addr_part, _ = IP.splitAddressMask(iaddr)
             if self.ip_address == addr_part:
                 has_ip = True
                 break

--- a/happy/HappyNodeJoin.py
+++ b/happy/HappyNodeJoin.py
@@ -30,6 +30,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyLink import HappyLink
 from happy.HappyNetwork import HappyNetwork
 from happy.HappyNode import HappyNode
@@ -199,13 +200,13 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
 
     def __check_node_hw_addr(self):
         hw_addr = self.getHwAddress(self.node_interface_name, self.node_id)
-        hw_addr_int = self.mac48_string_to_int(hw_addr)
+        hw_addr_int = IP.mac48_string_to_int(hw_addr)
 
         if (hw_addr_int & (1 << 41)):
             hw_addr_int = hw_addr_int & ~(1 << 41)
-            new_hw_addr = self.int_to_mac48_string(hw_addr_int)
+            new_hw_addr = IP.mac48_string_to_int(hw_addr_int)
 
-            cmd = "ip link set " + self.node_interface_name + " address " + new_hw_addr
+            cmd = "ip link set " + self.node_interface_name + " address " + str(new_hw_addr)
             cmd = self.runAsRoot(cmd)
             r = self.CallAtNode(self.node_id, cmd)
 
@@ -238,7 +239,7 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
             options["node_id"] = self.node_id
             options["interface"] = self.node_interface_name
 
-            if self.isIpv6(prefix):
+            if IP.isIpv6(prefix):
                 nid = self.getInterfaceId(self.node_interface_name, self.node_id)
             else:
                 nid = self.getNextNetworkIPv4Id(prefix, self.network_id)

--- a/happy/HappyNodeRoute.py
+++ b/happy/HappyNodeRoute.py
@@ -30,6 +30,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 from happy.HappyNetwork import HappyNetwork
 import happy.HappyNodeDelete
@@ -143,13 +144,13 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
             self.exit()
 
         # Check for mix IP addresses
-        if self.isIpAddress(self.to) and self.isIpAddress(self.via) and self.isIpv6(self.to) != self.isIpv6(self.via):
+        if IP.isIpAddress(self.to) and IP.isIpAddress(self.via) and IP.isIpv6(self.to) != IP.isIpv6(self.via):
             emsg = "Mixing addresses %s and %s." % (self.to, self.via)
             self.logger.error("[%s] HappyNodeRoute: %s" % (self.node_id, emsg))
             self.exit()
 
         # Check if destination is a node
-        if self.to != "default" and not self.isIpAddress(self.to):
+        if self.to != "default" and not IP.isIpAddress(self.to):
             if not self._nodeExists(self.to):
                 emsg = "Don't know what %s to-address is. If it is a node, it can't be found." % (self.to)
                 self.logger.error("[localhost] HappyNodeRoute: %s" % (emsg))
@@ -160,13 +161,13 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                 self.logger.error("[localhost] HappyNodeRoute: %s" % (emsg))
                 self.exit()
 
-        if self.isIpAddress(self.to):
-            self.to = self.paddingZeros(self.to)
+        if IP.isIpAddress(self.to):
+            self.to = IP.paddingZeros(self.to)
 
         # Check if gateway is a node
-        if self.isIpAddress(self.via):
+        if IP.isIpAddress(self.via):
             self.via_address = self.via
-            self.via_address = self.paddingZeros(self.via_address)
+            self.via_address = IP.paddingZeros(self.via_address)
             return
 
         if self._nodeInterfaceExists(self.via):
@@ -215,13 +216,13 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
             return
 
         else:
-            if not self.isIpAddress(self.prefix):
+            if not IP.isIpAddress(self.prefix):
                 emsg = "Prefix %s is not a valid IP address."
                 self.logger.error("[localhost] HappyNodeRoute: %s" % (emsg))
                 self.exit()
 
-            self.ip_prefix, self.ip_mask = self.splitAddressMask(self.prefix)
-            self.prefix = self.getPrefix(self.ip_prefix, self.ip_mask)
+            self.ip_prefix, self.ip_mask = IP.splitAddressMask(self.prefix)
+            self.prefix = IP.getPrefix(self.ip_prefix, self.ip_mask)
 
             gateway_addresses = self.getNodeAddressesOnNetworkOnPrefix(common_networks[0], self.prefix, self.via)
 
@@ -279,7 +280,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
             self.__call_add_route(4)
             self.__call_add_route(6)
         else:
-            if self.isIpv6(self.to) or self.isIpv6(self.via_address):
+            if IP.isIpv6(self.to) or IP.isIpv6(self.via_address):
                 self.__call_add_route(6)
             else:
                 self.__call_add_route(4)
@@ -307,7 +308,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
             self.__call_delete_route(4)
             self.__call_delete_route(6)
         else:
-            if self.isIpv6(self.to) or self.isIpv6(self.via_address):
+            if IP.isIpv6(self.to) or IP.isIpv6(self.via_address):
                 self.__call_delete_route(6)
             else:
                 self.__call_delete_route(4)
@@ -353,9 +354,9 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
         return False
 
     def __nodeRouteExistsViaAddress(self, to, via):
-        via = self.paddingZeros(via)
+        via = IP.paddingZeros(via)
         if to != 'default':
-            to = self.paddingZeros(to)
+            to = IP.paddingZeros(to)
 
         # IPv4
         cmd = "ip route"
@@ -369,7 +370,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                     continue
 
                 if to == 'default':
-                    if l[0] == to and l[1] == "via" and self.paddingZeros(l[2]) == via:
+                    if l[0] == to and l[1] == "via" and IP.paddingZeros(l[2]) == via:
                         if self.route_table is not None:
                             if self.nodeIpv4TableExist(self.node_id) is True:
                                 return True
@@ -377,7 +378,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                             return True
 
                 else:
-                    if self.paddingZeros(l[0]) == to and l[1] == "via" and self.paddingZeros(l[2]) == via:
+                    if IP.paddingZeros(l[0]) == to and l[1] == "via" and IP.paddingZeros(l[2]) == via:
                         if self.route_table is not None:
                             if self.nodeIpv4TableExist(self.node_id) is True:
                                 return True
@@ -394,14 +395,14 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                 if len(l) < 3:
                     continue
 
-                if self.paddingZeros(l[0]) == to and l[1] == "via" and self.paddingZeros(l[2]) == via:
+                if IP.paddingZeros(l[0]) == to and l[1] == "via" and IP.paddingZeros(l[2]) == via:
                     return True
 
         return False
 
     def __nodeRouteExistsViaDevice(self, to, dev):
         if to != 'default':
-            to = self.paddingZeros(to)
+            to = IP.paddingZeros(to)
 
         # IPv4
         cmd = "ip route"
@@ -422,7 +423,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                         return True
 
                 else:
-                    if self.paddingZeros(l[0]) == to and l[1] == "dev" and l[2] == dev:
+                    if IP.paddingZeros(l[0]) == to and l[1] == "dev" and l[2] == dev:
                         if self.route_table is not None:
                             if self.nodeIpv4TableExist(self.node_id) is True:
                                 return True
@@ -439,7 +440,7 @@ class HappyNodeRoute(HappyNode, HappyNetwork):
                 if len(l) < 3:
                     continue
 
-                if self.paddingZeros(l[0]) == to and l[1] == "dev" and l[2] == dev:
+                if IP.paddingZeros(l[0]) == to and l[1] == "dev" and l[2] == dev:
                     return True
 
         return False

--- a/happy/Ping.py
+++ b/happy/Ping.py
@@ -27,6 +27,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 
 options = {}
@@ -92,7 +93,7 @@ class Ping(HappyNode):
             self.exit()
 
         # Check if the destination node exists.
-        if not self.isIpAddress(self.destination) and not self._nodeExists(self.destination):
+        if not IP.isIpAddress(self.destination) and not self._nodeExists(self.destination):
             emsg = "virtual destination node %s does not exist." % (self.destination)
             self.logger.error("[%s] Ping: %s" % (self.source, emsg))
             self.exit()
@@ -105,7 +106,7 @@ class Ping(HappyNode):
     def __get_addresses(self):
         self.addresses = {}
 
-        if self.isIpAddress(self.destination):
+        if IP.isIpAddress(self.destination):
             self.addresses[self.destination] = 100
             return
 
@@ -118,7 +119,7 @@ class Ping(HappyNode):
     def __ping_on_address(self, addr):
         cmd = ""
 
-        if self.isIpv6(addr):
+        if IP.isIpv6(addr):
             cmd += "ping6"
         else:
             cmd += "ping"
@@ -128,7 +129,7 @@ class Ping(HappyNode):
         if self.size is not None:
             cmd += " -s " + str(self.size)
 
-        if self.isMulticast(addr):
+        if IP.isMulticast(addr):
             cmd += ""
 
         cmd += " " + addr
@@ -198,7 +199,7 @@ class Ping(HappyNode):
         self.__post_check()
 
         for addr in self.addresses.keys():
-            if self.isIpAddress(self.destination):
+            if IP.isIpAddress(self.destination):
                 self.logger.info("ping from " + self.source + " to address " +
                                  addr + " -> " + str(self.addresses[addr]) +
                                  "% packet loss")

--- a/happy/State.py
+++ b/happy/State.py
@@ -25,6 +25,7 @@
 
 import logging
 
+from happy.utils.IP import IP
 from happy.Driver import Driver
 
 
@@ -213,7 +214,7 @@ class State(Driver):
         for interface_id in node_public_interfaces:
             addresses = self.getNodeInterfaceAddresses(interface_id, node_id, state)
             for addr in addresses:
-                if self.isIpv4(addr):
+                if IP.isIpv4(addr):
                     return addr
         return None
 
@@ -254,7 +255,7 @@ class State(Driver):
         prefixes = []
         for addr in self.getNodeInterfaceAddresses(interface_id, node_id, state):
             mask = self.getNodeInterfaceAddressMask(interface_id, addr, node_id, state)
-            prefix = self.getPrefix(addr, mask)
+            prefix = IP.getPrefix(addr, mask)
             prefixes.append(prefix)
         return prefixes
 
@@ -427,7 +428,7 @@ class State(Driver):
         addrs = self.getNodeAddresses(node_id, state)
         res = []
         for addr in addrs:
-            if self.prefixMatchAddress(prefix, addr):
+            if IP.prefixMatchAddress(prefix, addr):
                 res.append(addr)
         return res
 
@@ -712,8 +713,8 @@ class State(Driver):
             if "route" not in node_record.keys():
                 node_record["route"] = {}
 
-            if ("via" in record.keys() and self.isIpv6(record["via"])) or \
-               ("prefix" in record.keys() and self.isIpv6(record["prefix"])):
+            if ("via" in record.keys() and IP.isIpv6(record["via"])) or \
+               ("prefix" in record.keys() and IP.isIpv6(record["prefix"])):
                 to = to + "_v6"
             else:
                 to = to + "_v4"
@@ -736,8 +737,8 @@ class State(Driver):
             if "route" not in network_record.keys():
                 network_record["route"] = {}
 
-            if ("via" in record.keys() and self.isIpv6(record["via"])) or \
-               ("prefix" in record.keys() and self.isIpv6(record["prefix"])):
+            if ("via" in record.keys() and IP.isIpv6(record["via"])) or \
+               ("prefix" in record.keys() and IP.isIpv6(record["prefix"])):
                 to = to + "_v6"
             else:
                 to = to + "_v4"

--- a/happy/Traceroute.py
+++ b/happy/Traceroute.py
@@ -27,6 +27,7 @@ import sys
 
 from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
+from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
 
 options = {}
@@ -89,7 +90,7 @@ class Traceroute(HappyNode):
             self.exit()
 
         # Check if the destination node exists.
-        if not self.isIpAddress(self.destination) and not self._nodeExists(self.destination):
+        if not IP.isIpAddress(self.destination) and not self._nodeExists(self.destination):
             emsg = "virtual destination node %s does not exist." % (self.destination)
             self.logger.error("[%s] Traceroute: %s" % (self.source, emsg))
             self.exit()
@@ -97,7 +98,7 @@ class Traceroute(HappyNode):
     def __get_addresses(self):
         self.addresses = {}
 
-        if self.isIpAddress(self.destination):
+        if IP.isIpAddress(self.destination):
             self.addresses[self.destination] = None
             return
 
@@ -110,12 +111,12 @@ class Traceroute(HappyNode):
     def __traceroute_to_address(self, addr):
         cmd = ""
 
-        if self.isIpv6(addr):
+        if IP.isIpv6(addr):
             cmd += "traceroute6"
         else:
             cmd += "traceroute"
 
-        if self.isMulticast(addr):
+        if IP.isMulticast(addr):
             cmd += ""
 
         cmd += " " + addr

--- a/happy/utils/IP.py
+++ b/happy/utils/IP.py
@@ -27,10 +27,8 @@ import socket
 
 
 class IP:
-    def __init__(self):
-        pass
-
-    def getIPv6Subnet(self, addr):
+    @staticmethod
+    def getIPv6Subnet(addr):
         a = addr.split(":")
 
         if len(a) > 3:
@@ -38,7 +36,8 @@ class IP:
         else:
             None
 
-    def getIPv6IID(self, addr):
+    @staticmethod
+    def getIPv6IID(addr):
         a = addr.split(":")
 
         if len(a) == 8:
@@ -46,8 +45,9 @@ class IP:
         else:
             return None
 
-    def paddingZeros(self, addr_mask):
-        if not self.isIpv6(addr_mask):
+    @staticmethod
+    def paddingZeros(addr_mask):
+        if not IP.isIpv6(addr_mask):
             return addr_mask
 
         if "/" in addr_mask:
@@ -80,7 +80,8 @@ class IP:
 
         return ret
 
-    def dropZeros(self, addr):
+    @staticmethod
+    def dropZeros(addr):
         prefix = []
         for a in reversed(addr.split(":")):
             if a == "0000" and prefix == []:
@@ -90,12 +91,13 @@ class IP:
         prefix.reverse()
         return ":".join(prefix)
 
-    def prefixMatchAddress(self, prefix, addr):
+    @staticmethod
+    def prefixMatchAddress(prefix, addr):
         if prefix is None:
             return False
 
-        aprefix, amask = self.splitAddressMask(prefix)
-        aprefix = self.dropZeros(aprefix)
+        aprefix, amask = IP.splitAddressMask(prefix)
+        aprefix = IP.dropZeros(aprefix)
 
         if len(aprefix) > len(addr):
             return False
@@ -104,7 +106,8 @@ class IP:
 
         return aprefix[:plen] == addr[:plen]
 
-    def getPrefix(self, addr, mask=None):
+    @staticmethod
+    def getPrefix(addr, mask=None):
         if "::" in addr:
             return addr.split("::")[0]
 
@@ -123,42 +126,48 @@ class IP:
             addr_list = addr.split(".")[:mask/8]
             return ".".join(addr_list)
 
-    def isIpv6(self, addr):
+    @staticmethod
+    def isIpv6(addr):
         if addr is None:
             return False
         return ':' in addr
 
-    def isIpv4(self, addr):
+    @staticmethod
+    def isIpv4(addr):
         if addr is None:
             return False
         return '.' in addr and not any(c.isalpha() for c in addr)
 
-    def isIpAddress(self, addr):
+    @staticmethod
+    def isIpAddress(addr):
         if addr is None:
             return False
-        return self.isIpv4(addr) or self.isIpv6(addr)
+        return IP.isIpv4(addr) or IP.isIpv6(addr)
 
-    def isMulticast(self, addr):
+    @staticmethod
+    def isMulticast(addr):
         if addr is None:
             return False
         return False
 
-    def splitAddressMask(self, ipmask):
+    @staticmethod
+    def splitAddressMask(ipmask):
         if '/' in ipmask:
             addr, mask = ipmask.split("/")
         else:
             addr = ipmask
-            if self.isIpv6(ipmask):
+            if IP.isIpv6(ipmask):
                 mask = 64     # By default we give mask of 64
             else:
                 mask = 24
 
-        if self.isIpv6(addr):
-            addr = self.paddingZeros(addr)
+        if IP.isIpv6(addr):
+            addr = IP.paddingZeros(addr)
 
         return (addr, mask)
 
-    def MAC48toEUI64(self, mac):
+    @staticmethod
+    def MAC48toEUI64(mac):
         addr = mac.split(":")
         if len(addr) != 6:
             return None
@@ -167,11 +176,12 @@ class IP:
         eui = "-".join(addr)
         return eui
 
-    def EUI64toIID(self, addr):
+    @staticmethod
+    def EUI64toIID(addr):
         int_addr = addr
 
         if type(addr) == str:
-            int_addr = self.eui64_string_to_int(addr)
+            int_addr = IP.eui64_string_to_int(addr)
 
         if int_addr >= 65536:
             if (1 << 57) > int_addr:
@@ -180,33 +190,36 @@ class IP:
                 int_addr = int_addr | (1 << 57)
 
         if type(addr) == str:
-            iid_addr = self.int_to_ipv6_addr_string(int_addr)
+            iid_addr = IP.int_to_ipv6_addr_string(int_addr)
 
         return iid_addr
 
-    def IIDtoEUI64(self, addr):
+    @staticmethod
+    def IIDtoEUI64(addr):
         eui_addr = addr
 
         if type(addr) == str:
-            eui_addr = self.ipv6_addr_string_to_int(addr)
+            eui_addr = IP.ipv6_addr_string_to_int(addr)
 
         eui_addr = ~pow(2, 57) & eui_addr
 
         if type(addr) == str:
-            eui_addr = self.int_to_eui64_string(eui_addr)
+            eui_addr = IP.int_to_eui64_string(eui_addr)
 
         return eui_addr
 
-    def mac48_string_to_int(self, hw_addr):
+    @staticmethod
+    def mac48_string_to_int(hw_addr):
         res = "0x"
-        for i in hw_addr.split(":"):
+        for i in str(hw_addr).split(":"):
             for x in range(2 - len(i)):
                 res += "0"
             res += i
         res = int(res, 16)
         return res
 
-    def eui64_string_to_int(self, eui_addr):
+    @staticmethod
+    def eui64_string_to_int(eui_addr):
         res = "0x"
         for i in eui_addr.split("-"):
             for x in range(2 - len(i)):
@@ -215,7 +228,8 @@ class IP:
         res = int(res, 16)
         return res
 
-    def ipv6_addr_string_to_int(self, ipv6_addr):
+    @staticmethod
+    def ipv6_addr_string_to_int(ipv6_addr):
         res = "0x"
         for i in ipv6_addr.split(":"):
             for x in range(4 - len(i)):
@@ -224,7 +238,8 @@ class IP:
         res = int(res, 16)
         return res
 
-    def int_to_eui64_string(self, int_val):
+    @staticmethod
+    def int_to_eui64_string(int_val):
         res = hex(int_val)
         res = str(res)
         if res[-1] == "L":
@@ -240,7 +255,8 @@ class IP:
         res = "-".join(res)
         return str(res)
 
-    def int_to_mac48_string(self, int_val):
+    @staticmethod
+    def int_to_mac48_string(int_val):
         res = hex(int_val)
         res = str(res)
         if res[-1] == "L":
@@ -256,7 +272,8 @@ class IP:
         res = ":".join(res)
         return str(res)
 
-    def int_to_ipv6_addr_string(self, int_val):
+    @staticmethod
+    def int_to_ipv6_addr_string(int_val):
         res = hex(int_val)
         res = str(res)
         if res[-1] == "L":
@@ -272,9 +289,11 @@ class IP:
         res = ":".join(res)
         return str(res)
 
-    def isDomainName(self, domain):
-        return "." in domain and not self.isIpv4(domain)
+    @staticmethod
+    def isDomainName(domain):
+        return "." in domain and not IP.isIpv4(domain)
 
-    def getHostByName(self, name):
+    @staticmethod
+    def getHostByName(name):
         ip = socket.gethostbyname(name)
         return ip


### PR DESCRIPTION
IP.py was the first layer of HappyNode inheritance, but actually IP.py is just some utils which has no need to be part of the object inheritance. 
So I have made changes to move IP.py out of the object inheritance, and make it to be a standard happy util.
Happy tool change proposal doc is here:
https://docs.google.com/document/d/17G6opOS5qXC-YVbpg7PDMfnmzkPfY_eMrpRxfOT7QwM/edit?usp=sharing