### PR TITLE
[HappyInternet] ISP id needs to be set with prefix

### DIFF
--- a/happy/HappyInternet.py
+++ b/happy/HappyInternet.py
@@ -86,13 +86,12 @@ class HappyInternet(HappyNode, HappyNodeRoute):
         self.seed = int(opts["seed"])
         self.prefix = '172.16.' + opts["seed"] + '.'
 
-        if self.add:
-            if "weave_service_address" in os.environ.keys():
-                tier = os.environ['weave_service_address'].split(".")[3][0:3]
-                self.isp_id = tier + self.isp_id
-            else:
-                tier = "test"
-                self.isp_id = tier + self.isp_id
+        if "weave_service_address" in os.environ.keys():
+            tier = os.environ['weave_service_address'].split(".")[-3][0:3]
+            self.isp_id = tier + self.isp_id
+        else:
+            tier = "test"
+            self.isp_id = tier + self.isp_id
 
         self.mask = "24"
         self.host_addr = self.prefix + "1"


### PR DESCRIPTION
HappyInternet delete is broken, currently the isp prefix is only to be added when adding, but it also needs the prefix when deleting.  When setting isp with different service tier, the prefix needs to be set when adding and deleting.  Fix prefix naming bug, prefix is to use the last third words[0:3] instead of the first third from nest url if testing with real tier, otherwise it just uses test.