### PR TITLE
Add net-tools As a Required Dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ SUDO               ?= sudo
 
 DPKG_PREREQUISITES := \
     bridge-utils      \
+    net-tools         \
     python-lockfile   \
     python-psutil     \
     python-setuptools \


### PR DESCRIPTION
Based on [openweave-users mailing list discussion](https://groups.google.com/d/msg/openweave-users/sKZjqFVoGxM/pWvMqsnMBwAJ), it was identified that net-tools is a required dependency for Happy.

This adds the explicit dependency to the list of Debian package dependencies that are checked on Happy installation.