### PR TITLE
happy-state node

### DIFF
--- a/bin/happy-state.py
+++ b/bin/happy-state.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
     options = happy.HappyState.option()
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hqs:gljuia",
-                                   ["help", "quiet", "save=", "graph", "log", "json", "unlock", "id", "all"])
+        opts, args = getopt.getopt(sys.argv[1:], "hqs:gljuian:",
+                                   ["help", "quiet", "save=", "graph", "log", "json", "unlock", "id", "all", "node="])
 
     except getopt.GetoptError as err:
         print happy.HappyState.HappyState.__doc__
@@ -71,8 +71,14 @@ if __name__ == "__main__":
         elif o in ("-a", "--all"):
             options["all"] = True
 
+        elif o in ("-n", "--node"):
+            options["node"] = a
+
         else:
             assert False, "unhandled option"
+
+    if len(args) == 1:
+        options["node"] = args[0]
 
     cmd = happy.HappyState.HappyState(options)
     cmd.start()

--- a/happy/HappyState.py
+++ b/happy/HappyState.py
@@ -54,6 +54,7 @@ options["json"] = False
 options["unlock"] = False
 options["id"] = False
 options["all"] = False
+options["node"] = None
 
 
 def option():
@@ -66,6 +67,7 @@ class HappyState(State):
 
     happy-state [-h --help] [-q --quiet] [-s --save <JSON_FILE>] [-g --graph]
                 [-l --logs] [-j --json] [-u --unlock] [-i --id] [-a --all]
+                [-n --node <node name>]
 
         -s --save   Saves the current network topology state in a JSON file.
         -g --graph  Generates a network topology graph.
@@ -75,6 +77,7 @@ class HappyState(State):
         -u --unlock Force unlock the Happy state file (~/.happy_state.json).
         -i --id     Displays all known state IDs.
         -a --all    Displays the network topology state for all known states.
+        -n --node   Displays all information for a node
 
     Examples:
     $ happy-state
@@ -102,13 +105,14 @@ class HappyState(State):
         self.unlock_state = opts["unlock"]
         self.show_id = opts["id"]
         self.all = opts["all"]
+        self.node = opts["node"]
 
     def __pre_check(self):
         pass
 
     def __print_data_state(self):
         if self.quiet or self.graph or self.save or self.log or self.json or \
-           self.unlock_state or self.show_id:
+           self.unlock_state or self.show_id or self.node:
             return
 
         self.__print_own_state()
@@ -177,6 +181,25 @@ class HappyState(State):
 
         with open(self.save, 'w') as jfile:
             jfile.write(json_data)
+
+    def __print_node_state(self):
+        """print_node_state
+        print single node information
+        """
+        if self.node is None:
+            return
+        node_info = {}
+
+        print
+
+        print "State Name: {}".format(self.getStateId())
+
+        print "Node: {}".format(self.node)
+
+        node_info = self.getNodeInfo(self.node)
+        node_json_data = json.dumps(node_info, sort_keys=True, indent=2)
+        print node_json_data
+
 
     def __graph_state(self):
         if self.graph is None:
@@ -363,6 +386,7 @@ class HappyState(State):
         self.__show_state_id()
         self.__save_state()
         self.__graph_state()
+        self.__print_node_state()
         self.__show_logs()
 
         self.__post_check()

--- a/happy/State.py
+++ b/happy/State.py
@@ -851,3 +851,61 @@ class State(Driver):
         global_record = self.getGlobal(state)
         if "DNS" in global_record.keys():
             del global_record["DNS"]
+
+    def getWeaveInfo(self, state=None):
+        """
+        return weave information from topology
+        """
+        state = self.getState(state)
+        if "weave" not in state.keys():
+            state["weave"] = {}
+        return state["weave"]
+
+    def getWeaveNodeInfo(self, node, state=None):
+        """
+        return weave node information
+        example for one weave node result:
+        {
+            "eui64": "cd-e8-d1-d0-5a-ed-11-e9",
+            "iid": "cfe8:d1d0:5aed:11e9",
+            "pairing_code": "KIQKVL",
+            "weave_node_id": "cde8d1d05aed11e9"
+        }
+        """
+        state = self.getWeaveInfo()
+        if "node" not in state.keys():
+            return None
+        elif node not in state["node"].keys():
+            return None
+        else:
+            return state["node"][node]
+
+    def getWeaveNodeId(self, node, state=None):
+        """
+        return weave node id
+        """
+        weave_node_info = self.getWeaveNodeInfo(node, state)
+        if "weave_node_id" not in weave_node_info:
+            return None
+        else:
+            return weave_node_info["weave_node_id"]
+
+
+    def getWeaveFabric(self, state=None):
+        state = self.getWeaveInfo()
+        if "fabric" not in state.keys():
+            return None
+        else:
+            return state["fabric"]
+
+    def getNodeInfo(self, node, state=None):
+        """
+        get all information of a node
+        """
+        happy_node_info = self.getNodes()[node]
+        weave_node_info = self.getWeaveNodeInfo(node)
+
+        node_info = {"happy": happy_node_info,
+                     "weave": weave_node_info
+                     }
+        return node_info


### PR DESCRIPTION
https://github.com/openweave/happy/issues/26
Since we already have all node information saved in ~/.happy_state.json, it is easy to get one particular node information from the json file.
User should be able to use happy-state <node> to display one particular node information.
https://docs.google.com/document/d/10c4xptq9qgVERD0IVRZPfvcJEdZZx7BL2cAbgKYiK9g/edit?usp=sharing
output of happy-state <node> is below:

jexie@jexie0:~/github/happy/bin$ happy-state BorderRouter

State Name: happy
Node: BorderRouter
{
  "happy": {
    "interface": {
      "wlan0": {
        "ip": {
          "10.0.1.2": {
            "mask": 24
          }, 
          "2001:0db8:0222:0002:cefc:cfff:fe67:d4f2": {
            "mask": 64
          }, 
          "fd00:0000:fab1:0001:cfe8:d1d0:5aed:11e9": {
            "mask": 64
          }
        }, 
        "link": "wifi0", 
        "type": "wifi"
      }, 
      "wpan0": {
        "ip": {
          "2001:0db8:0111:0001:c617:beff:fe18:0b5d": {
            "mask": 64
          }, 
          "fd00:0000:fab1:0006:cfe8:d1d0:5aed:11e9": {
            "mask": 64
          }
        }, 
        "link": "thread1", 
        "type": "thread"
      }
    }, 
    "process": {}, 
    "route": {
      "default_v4": {
        "prefix": "10.0.1", 
        "to": "default", 
        "via": "onhub"
      }
    }, 
    "tmux": {}, 
    "type": null
  }, 
  "weave": {
    "eui64": "cd-e8-d1-d0-5a-ed-11-e9", 
    "iid": "cfe8:d1d0:5aed:11e9", 
    "pairing_code": "KIQKVL", 
    "weave_node_id": "cde8d1d05aed11e9"
  }
}
