### PR TITLE
organize test log

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,19 @@
+# How does Happy test log work
+
+## Types of Happy logs
+
+  * Debug logs - Logs related to Happy's role as test coordinator and orchestrator, where it facilitates the activities of virtual device nodes.
+
+  * Device logs - Logs related to software such as OpenWeave running on individual virtual device nodes within a Happy test network. OpenWeave is one of the software example, device logs may have OpenWeave logs.
+
+## Where Happy logs are stored
+
+  * If the `HAPPY_LOG_DIR` environment variable exists, Happy uses the `HAPPY_LOG_DIR` value as log folder location to store Happy test logs.
+
+  * If the `HAPPY_LOG_DIR` environment variable doesn't exist, Happy uses the `default_happy_log_dir` value from [happy/conf/main_config.json](https://github.com/openweave/happy/blob/master/happy/conf/main_config.json) as the default log folder location to store Happy test logs. The default value of `default_happy_log_dir` is `/tmp`.
+
+## How to set `HAPPY_LOG_DIR`
+
+  There are multiple ways to see the `HAPPY_LOG_DIR` environment variable::
+  * If your project is being built with GNU autotools and you are running functional and unit tests with Happy with the DejaGnu test framework, then you might add `HAPPY_LOG_DIR=<dir value>` to TESTS_ENVIRONMENT in your Makefile.am or Makefile.in.
+  * Add `HAPPY_LOG_DIR=<dir value>` to .bashrc and source it before you run the test script.

--- a/happy/Driver.py
+++ b/happy/Driver.py
@@ -195,6 +195,28 @@ class Driver:
             print "Failed to get state id from %s." % (self.main_conf_file)
             sys.exit(1)
 
+        # default_happy_log_dir will be default dir for happy log
+        # happy_log_environ is os environment variable passed from test-engine
+        try:
+            self.default_happy_log_dir = self.main_conf["default_happy_log_dir"]
+        except Exception:
+            print "Failed to find default_happy_log dir in the main configuration file %s." \
+                % (self.main_conf_file)
+            sys.exit(1)
+
+        try:
+            self.happy_log_environ = "HAPPY_LOG_DIR"
+        except Exception:
+            print "Failed to find happy log environment variable name in the main configuration file %s." \
+                % (self.main_conf_file)
+            sys.exit(1)
+
+        try:
+            self.happy_log_dir = self.getHappyLogDir()
+        except Exception:
+            print "Failed to get happy log dir from %s." % (self.main_conf_file)
+            sys.exit(1)
+
         try:
             self.state_file_prefix = self.main_conf["state_file_prefix"]
             self.state_file_suffix = self.main_conf["state_file_suffix"]
@@ -233,8 +255,9 @@ class Driver:
         try:
             confDict = dict(self.main_conf)
             confDict['state_id'] = self.state_id
-            self.log_conf['handlers']['file']['filename'] = self.log_conf['handlers']['file']['filename'] % confDict
+            confDict['happy_log_dir'] = self.happy_log_dir
 
+            self.log_conf['handlers']['file']['filename'] = self.log_conf['handlers']['file']['filename'] % confDict
             self.log_conf['handlers']['file']['level'] = logging.getLevelName(self.log_level_file)
             self.log_conf['handlers']['stream']['level'] = logging.getLevelName(self.log_level_console)
 
@@ -294,9 +317,10 @@ class Driver:
 
             confDict = dict(self.main_conf)
             confDict['state_id'] = self.state_id
+            confDict['happy_log_dir'] = self.happy_log_dir
 
-            if not os.path.exists(confDict["log_directory"]):
-                os.makedirs(confDict["log_directory"])
+            if not os.path.exists(self.happy_log_dir):
+                os.makedirs(self.happy_log_dir)
 
             self.process_log_prefix = self.main_conf["process_log_prefix"] % confDict
 
@@ -589,3 +613,9 @@ class Driver:
             return os.environ[self.state_environ]
         else:
             return self.default_state
+
+    def getHappyLogDir(self):
+        if self.happy_log_environ in os.environ.keys():
+            return os.environ[self.happy_log_environ]
+        else:
+            return self.default_happy_log_dir

--- a/happy/conf/log_config.json
+++ b/happy/conf/log_config.json
@@ -14,7 +14,7 @@
             "level": "DEBUG",
             "class" : "logging.handlers.RotatingFileHandler",
             "formatter": "standard",
-            "filename":"%(log_directory)s/%(state_id)s_debug_log.txt",
+            "filename":"%(happy_log_dir)s/%(state_id)s_debug_log.txt",
             "maxBytes": "5242880"
         },
         "stream": {

--- a/happy/conf/main_config.json
+++ b/happy/conf/main_config.json
@@ -1,10 +1,11 @@
 {
     "configuration_file":"~/.happy_conf.json",
     "log_directory":"/tmp",
+    "default_happy_log_dir":"/tmp",
     "log_level_file": "DEBUG",
     "log_level_console": "INFO",
     "default_state":"happy",
-    "process_log_prefix":"%(log_directory)s/%(state_id)s_",
+    "process_log_prefix":"%(happy_log_dir)s/%(state_id)s_",
     "state_environ":"HAPPY_STATE_ID",
     "state_file_prefix":"~/.",
     "state_file_suffix":"_state.json",

--- a/happy/version.py
+++ b/happy/version.py
@@ -17,4 +17,4 @@
 #    limitations under the License.
 #
 
-__version__ = '1.1.36'
+__version__ = '1.1.37'


### PR DESCRIPTION
organize test logs to under build folder by using “abs_logdir” in os.environ, there are 3 category logs:
1. Device(happy node) logs handled in happy/HappyProcessStart.py
2. Happy_debug_log.txt handled in Driver.py 
3. Persistent log handled in WeaveTest.py (this will be addressed in another openweave PR)

The abs_logdir value will be assigned from setup() in test script, and will be covered in another PR in openweave-core.
example code in openweave-core to assign value to abs_logdir in test script:

 self.feature_dir = re.findall(
            r'.*openweave-core/src/test-apps/happy/tests/(.*)', os.path.dirname(os.path.abspath(__file__)))[0]

os.environ['abs_logdir'] = os.environ['abs_builddir'] + '/happy/test_logs/' + self.feature_dir + '/'

All changes have been tested and verified OK.
PR from openweave-core related to this feature:
https://github.com/openweave/openweave-core/pull/265