### PR TITLE
no need assign IP if device is a tap device Happy topology creation.

### DIFF
--- a/happy/HappyNodeJoin.py
+++ b/happy/HappyNodeJoin.py
@@ -231,6 +231,10 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
         self.setNodeInterface(self.node_id, self.node_interface_name, new_node_interface)
 
     def __assign_network_addresses(self):
+        #  if node is a tap device, no need to assign IP to it.
+        if self.tap:
+            self.logger.error("HappyNodeJoin: {} is tap device, do not assign IP".format(self.node_id))
+            self.exit()
         network_prefixes = self.getNetworkPrefixes(self.network_id)
 
         for prefix in network_prefixes:
@@ -296,7 +300,9 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
 
             self.writeState()
 
-        self.__assign_network_addresses()
+        #  if node is a tap device, no need to assign IP to it.
+        if not self.tap:
+            self.__assign_network_addresses()
 
         self.__load_network_routes()
 


### PR DESCRIPTION
no need assign IP if device is a tap device Happy topology creation.
Lwip stack will handle tap device IP assignment.