### PR TITLE
Rewrite the HappyProcessStart to more correctly deal with environment

### DIFF
--- a/happy/Driver.py
+++ b/happy/Driver.py
@@ -544,23 +544,30 @@ class Driver:
     def CallAtNetworkForOutput(self, network_id, cmd, env=None):
         return self.CallAtNodeForOutput(network_id, cmd, env)
 
-    def runAsRoot(self, cmd):
+    def getRunAsRootPrefixList(self):
         if "SUDO" in os.environ.keys():
-            return os.environ["SUDO"] + " " + cmd
+            return [os.environ["SUDO"]]
         elif os.getuid() == 0:
             # We are already root
-            return cmd
+            return []
         else:
-            return "sudo " + cmd
+            return ["sudo"]
 
-    def runAsUser(self, cmd, username=None):
+
+    def runAsRoot(self, cmd):
+        return ' '.join(self.getRunAsRootPrefixList() + [cmd])
+
+    def getRunAsUserPrefixList(self, username=None):
         if username is None:
             username = getpass.getuser()
 
         if "SUDO" in os.environ.keys():
-            return "$SUDO -u " + username + " " + cmd
+            return [os.environ["SUDO"], "-u", username]
         else:
-            return "sudo -u " + username + " " + cmd
+            return ["sudo", "-u", username]
+
+    def runAsUser(self, cmd, username=None):
+        return ' '.join(self.getRunAsUserPrefixList(username=username) + [cmd])
 
     def uniquePrefix(self, txt, state=None):
         prefix = self.getStateId(state)

--- a/happy/HappyProcessStart.py
+++ b/happy/HappyProcessStart.py
@@ -295,19 +295,16 @@ class HappyProcessStart(HappyNode, HappyProcess):
             need_bash = True
 
         if need_internal_sudo:
-            tmp = "ls"
             if self.rootMode:
-                tmp = self.runAsRoot(tmp)
+                tmp = self.getRunAsRootPrefixList()
             else:
-                tmp = self.runAsUser(tmp)
-            cmd_list_prefix = tmp.split()[:-1] + cmd_list_prefix
+                tmp = self.getRunAsUserPrefixList()
+            cmd_list_prefix = tmp + cmd_list_prefix
 
         if self.node_id:
             cmd_list_prefix = ["ip", "netns", "exec", self.uniquePrefix(self.node_id)] + cmd_list_prefix
 
-        tmp = 'ls'
-        tmp = self.runAsRoot(tmp)
-        cmd_list_prefix = tmp.split()[:-1] + cmd_list_prefix
+        cmd_list_prefix = self.getRunAsRootPrefixList() + cmd_list_prefix
 
         try:
             self.fout = open(self.output_file, "w", 0)


### PR DESCRIPTION
The existing implementation of HappyProcessStart had a number of bugs
in cases where the environment variables contained "complicated"
values, i.e. values containing spaces, quotes, backslashes,
semicolons, etc. This implementation improves on the previous
implementation in that the environment variables can now contain the
above characters and will be properly escaped.