### PR TITLE
Config TAP device in topology json file

### DIFF
--- a/bin/happy-node-route.py
+++ b/bin/happy-node-route.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
     options = happy.HappyNodeRoute.option()
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hi:qadt:v:p:s:e:",
-                                   ["help", "id=", "quiet", "add", "delete", "to=", "via=", "prefix=", "isp=", "seed="])
+        opts, args = getopt.getopt(sys.argv[1:], "hi:qadt:v:p:s:e:y:",
+                                   ["help", "id=", "quiet", "add", "delete", "to=", "via=", "prefix=", "isp=", "seed=", "type="])
 
     except getopt.GetoptError as err:
         print happy.HappyNodeRoute.HappyNodeRoute.__doc__
@@ -73,6 +73,9 @@ if __name__ == "__main__":
 
         elif o in ("-e", "--seed"):
             options["seed"] = True
+
+        elif o in ("-y", "--type"):
+            options["route_type"] = a
 
         else:
             assert False, "unhandled option"

--- a/happy/HappyNetworkRoute.py
+++ b/happy/HappyNetworkRoute.py
@@ -235,12 +235,13 @@ class HappyNetworkRoute(HappyNetwork, HappyNode):
 
     def run(self):
         with self.getStateLockManager():
-
             self.__pre_check()
 
         self.__configure_nodes_routes()
-
-        self.__configure_gateway_routing()
+        # For TAP device, happy will not configure address/routing
+        # And it will be configured by LwIP stack in whatever process LwIP is running
+        if not self.IsTapDevice(self.node_id):
+            self.__configure_gateway_routing()
 
         with self.getStateLockManager():
 

--- a/happy/HappyNodeAddress.py
+++ b/happy/HappyNodeAddress.py
@@ -31,6 +31,7 @@ from happy.ReturnMsg import ReturnMsg
 from happy.Utils import *
 from happy.utils.IP import IP
 from happy.HappyNode import HappyNode
+import json
 
 options = {}
 options["quiet"] = False
@@ -187,21 +188,30 @@ class HappyNodeAddress(HappyNode):
             self.removeNodeInterfaceAddress(self.node_id, self.interface, self.ip_address)
 
     def run(self):
-        with self.getStateLockManager():
+        if not self.add and not self.delete:
+            data_state = json.dumps(self.getNodeInterfaceAddresses(self.interface, self.node_id), sort_keys=True, indent=4)
 
-            self.__pre_check()
+            emsg = "virtual node: " + self.node_id + " addresses list for interface id: " + self.interface
 
-            if not self.done:
+            print emsg
+            print data_state
 
-                if self.add:
-                    self.__add_address()
-                else:
-                    self.__delete_address()
+        else:
+            with self.getStateLockManager():
 
-                self.__post_check()
+                self.__pre_check()
 
-                self.__update_state()
+                if not self.done:
+                    if not self.IsTapDevice(self.node_id):
+                        if self.add:
+                            self.__add_address()
+                        else:
+                            self.__delete_address()
 
-                self.writeState()
+                        self.__post_check()
+
+                    self.__update_state()
+
+                    self.writeState()
 
         return ReturnMsg(0)

--- a/happy/HappyNodeJoin.py
+++ b/happy/HappyNodeJoin.py
@@ -231,10 +231,6 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
         self.setNodeInterface(self.node_id, self.node_interface_name, new_node_interface)
 
     def __assign_network_addresses(self):
-        #  if node is a tap device, no need to assign IP to it.
-        if self.tap:
-            self.logger.error("HappyNodeJoin: {} is tap device, do not assign IP".format(self.node_id))
-            self.exit()
         network_prefixes = self.getNetworkPrefixes(self.network_id)
 
         for prefix in network_prefixes:
@@ -300,9 +296,8 @@ class HappyNodeJoin(HappyLink, HappyNode, HappyNetwork):
 
             self.writeState()
 
-        #  if node is a tap device, no need to assign IP to it.
-        if not self.tap:
-            self.__assign_network_addresses()
+        
+        self.__assign_network_addresses()
 
         self.__load_network_routes()
 

--- a/happy/State.py
+++ b/happy/State.py
@@ -265,6 +265,28 @@ class State(Driver):
             return {}
         return node_record["route"]
 
+    def getNodeRoutePrefix(self, route_type, node_id=None, state=None):
+        """
+        getting node route prefix base on route type "v4" or "v6"
+        """
+        node_routes = self.getNodeRoutes(node_id, state)
+        for node_route in node_routes.keys():
+            if route_type in node_route:
+                return node_routes[node_route]["prefix"]
+        else:
+            return None
+
+    def getNodeRouteVia(self, route_type, node_id=None, state=None):
+        """
+        getting node route via node id base on route type "v4" or "v6"
+        """
+        node_routes = self.getNodeRoutes(node_id, state)
+        for node_route in node_routes.keys():
+            if route_type in node_route:
+                return node_routes[node_route]["via"]
+        else:
+            return None
+
     def getNodeRouteIds(self, node_id=None, state=None):
         node_routes = self.getNodeRoutes(node_id, state)
         return node_routes.keys()
@@ -892,3 +914,25 @@ class State(Driver):
                 ext_states = ext_states[item]
                 ext_value = ext_states
         return ext_value
+
+    def IsTapDevice(self, node_id, state=None):
+        """
+        check if a device is a tap device or not
+        if tap device, will not call netns command to add route
+        1. get links of a node
+        2. verify link is TAP or not
+        Happy only support one interface type now,
+        it is either tap device or regular linux socket device
+        """
+        node_links = self.getNodeLinkIds(node_id)
+        # no link_id for cloud node service-tun0 interface
+        if None in node_links:
+            node_links.remove(None)
+        for link in node_links:
+            if self.getLinkTap(link):
+                return True
+        else:
+            return False
+
+
+        


### PR DESCRIPTION
added API in happy to help configure TAP device in topology json file

To get device IP for a particular interface:
jexie@jexie0:~/github/openweave-core/src/test-apps/happy/topologies/standalone$ happy-node-address -i BorderRouter -e wlan0
virtual node: BorderRouter addresses list for interface id: wlan0
[
    "fd00:0000:fab1:0001:f674:0daa:bdf2:11e9", 
    "10.0.1.2", 
    "2001:0db8:0222:0002:5a7c:b6ff:fe44:a118"
]

To get route IP for a particular device:
jexie@jexie0:~/github/happy$ happy-node-route -i BorderRouter -y v4
virtual node: BorderRouter, route_type: v4, route ip: [u'10.0.1.3']
